### PR TITLE
Polish the syntax highlighting and add {% raw %} where needed

### DIFF
--- a/_docs/config.md
+++ b/_docs/config.md
@@ -57,8 +57,12 @@ While `url`is not a mandatory config key, it is automatically set in development
 
 Prefer the `absolute_url` and `relative_url` filters in templates to calling `site.github` or `site.baseurl` directly to better account for environment and configuration inconsistencies.
 
+<!-- {% raw %} -->
+
 ```liquid
 <a href="{{ post.url | absolute_url }}">Post</a>
 
 <a href="{{ "foo" | relative_url }}">Foo</a>
 ```
+
+<!-- {% endraw %} -->

--- a/_docs/liquid-syntax.md
+++ b/_docs/liquid-syntax.md
@@ -4,7 +4,7 @@ title: Liquid syntax
 
 ### General Syntax
 
-* Use a space between opening and closing tags. Good: {% raw %}`{{ site.title }}`{% endraw %}, Bad: {% raw %}`{{site.title}}`{% endraw %}
+* Use a space between opening and closing tags. Good: <!-- {% raw %} -->`{{ site.title }}`<!-- {% endraw %} -->, Bad: <!-- {% raw %} -->`{{site.title}}` <!--{% endraw %} -->
 
 ### Indentation
 
@@ -12,7 +12,8 @@ Place sequential statements at the same indentation level and indent nested stat
 
 Good:
 
-{% raw %}
+<!-- {% raw %} -->
+
 ```html
 {% assign handle = 'cake' %}
 {% case handle %}
@@ -24,11 +25,13 @@ Good:
      <p>This is not a cake nor a cookie</p>
 {% endcase %}
 ```
-{% endraw %}
+
+<!--{% endraw %} -->
 
 Bad:
 
-{% raw %}
+<!-- {% raw %} -->
+
 ```html
 {% assign handle = 'cake' %}
 {% case handle %}
@@ -40,7 +43,8 @@ Bad:
 <p>This is not a cake nor a cookie</p>
 {% endcase %}
 ```
-{% endraw %}
+
+<!--{% endraw %} -->
 
 ### Vertical Whitespace
 
@@ -48,7 +52,8 @@ Place empty lines between unrelated code blocks to improve readability.
 
 Good:
 
-{% raw %}
+<!-- {% raw %} -->
+
 ```html
 {% if page.title %}
   <h1>{{ page.title }}</h1>
@@ -58,11 +63,13 @@ Good:
   <p>{{ page.description }}</p>
 {% endif %}
 ```
-{% endraw %}
+
+<!--{% endraw %} -->
 
 Bad:
 
-{% raw %}
+<!-- {% raw %} -->
+
 ```html
 {% if page.title %}
   <h1>{{ page.title }}</h1>
@@ -71,4 +78,5 @@ Bad:
   <p>{{ page.description }}</p>
 {% endif %}
 ```
-{% endraw %}
+
+<!--{% endraw %} -->

--- a/_docs/liquid-syntax.md
+++ b/_docs/liquid-syntax.md
@@ -14,7 +14,7 @@ Good:
 
 <!-- {% raw %} -->
 
-```html
+```liquid
 {% assign handle = 'cake' %}
 {% case handle %}
   {% when 'cake' %}
@@ -32,7 +32,7 @@ Bad:
 
 <!-- {% raw %} -->
 
-```html
+```liquid
 {% assign handle = 'cake' %}
 {% case handle %}
 {% when 'cake' %}
@@ -54,7 +54,7 @@ Good:
 
 <!-- {% raw %} -->
 
-```html
+```liquid
 {% if page.title %}
   <h1>{{ page.title }}</h1>
 {% endif %}
@@ -70,7 +70,7 @@ Bad:
 
 <!-- {% raw %} -->
 
-```html
+```liquid
 {% if page.title %}
   <h1>{{ page.title }}</h1>
 {% endif %}

--- a/_docs/permalinks.md
+++ b/_docs/permalinks.md
@@ -28,10 +28,10 @@ Good:
 
 In `about.md` (accessible as `/about/`):
 
-```
+```yaml
 ---
 title: About
-permalink: `/about/`
+permalink: /about/
 ---
 ```
 
@@ -39,7 +39,7 @@ Bad:
 
 In `about/index.md` (accessible as `/about/`):
 
-```
+```yaml
 ---
 title: About
 ---

--- a/_docs/themes.md
+++ b/_docs/themes.md
@@ -10,7 +10,7 @@ The theme's primary Sass include should match the full theme name (e.g., `_sass/
 
 The theme's primary stylesheet should live at `assets/css/style.scss` and contain *only* the following content (with "[THEME NAME]" being the name of your theme's primary Sass include):
 
-```liquid
+```sass
 ---
 ---
 
@@ -34,8 +34,8 @@ Themes should, at minimum, respect the following configuration variables, if set
 
 If intended to be used on GitHub Pages, themes should default to the following variables, if the above variables are not set:
 
-* For `title`, themes should default to `site.github.repository_name` (e.g., `{{ title | default: site.github.repository_name }}`)
-* For `description`, themes should default to `site.github.project_description` (e.g., `{{ title | default: site.github.project_description }}`)
+* For `title`, themes should default to `site.github.repository_name` (e.g., <!-- {% raw %} -->`{{ title | default: site.github.repository_name }}`<!-- {% endraw %} -->)
+* For `description`, themes should default to `site.github.project_description` (e.g., <!-- {% raw %} -->`{{ title | default: site.github.project_description }}`<!-- {% endraw %} -->)
 
 Additionally, themes may choose to honor the following variables, if set in the user's `_config.yml`:
 


### PR DESCRIPTION
By putting the `{% raw %}` blocks in HTML comments, the pages still look good on GitHub.